### PR TITLE
Add static method `test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
     "name": "Chris Feijoo",
     "url": "https://github.com/kube"
   },
+  "contributors": [
+    {
+      "name": "Cezary Drożak",
+      "url": "https://github.com/nawordar"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/kube/when-switch/issues"

--- a/src/__tests__/true.spec.ts
+++ b/src/__tests__/true.spec.ts
@@ -1,4 +1,13 @@
 
+      /*#######.
+     ########",#:
+   #########',##".
+  ##'##'## .##',##.
+   ## ## ## # ##",#.
+    ## ## ## ## ##'
+     ## ## ## :##
+      ## ## ##*/
+
 import when from '../when'
 import { StaticCheck, IsType, IsSubtype } from './helpers';
 

--- a/src/__tests__/true.spec.ts
+++ b/src/__tests__/true.spec.ts
@@ -1,0 +1,77 @@
+
+import when from '../when'
+import { StaticCheck, IsType, IsSubtype } from './helpers';
+
+describe("'when.true' syntax with a simple return type", () => {
+  const getDrinkPrice = (drink: 'Pepsi' | 'Coke' | 'Orangina'): number =>
+    when
+      .true(() => drink === 'Coke', 1.5)
+      .true(() => drink === 'Pepsi', 1.8)
+      .else(2.0)
+
+  StaticCheck<IsType<number, ReturnType<typeof getDrinkPrice>>>()
+
+  it('returns value if assertion is true', () => {
+    expect(getDrinkPrice('Coke')).toEqual(1.5)
+    expect(getDrinkPrice('Pepsi')).toEqual(1.8)
+  })
+
+  it('returns default value if any of assertions is true', () => {
+    expect(getDrinkPrice('Orangina')).toEqual(2.0)
+  })
+})
+
+describe("'when.true' syntax with a union return-type", () => {
+  const getDrinkPrice = (drink: 'Pepsi' | 'Coke' | 'Orangina'): number | string | boolean =>
+    when
+      .true(drink === 'Coke', 1.5)
+      .true(drink === 'Pepsi', true)
+      .else('Free')
+
+  StaticCheck<IsSubtype<number | boolean | string, ReturnType<typeof getDrinkPrice>>>()
+
+  it('returns value if matches an expression', () => {
+    expect(getDrinkPrice('Coke')).toEqual(1.5)
+    expect(getDrinkPrice('Pepsi')).toEqual(true)
+  })
+
+  it('returns default value if no match', () => {
+    expect(getDrinkPrice('Orangina')).toEqual('Free')
+  })
+})
+
+describe("'when.true' syntax with a function as `is` return value", () => {
+  type Action = { type: string }
+
+  const apply = (action: Action) =>
+    when
+      .true(action.type === 'INCREMENT', () => 2)
+      .true(action.type === 'DECREMENT', () => true)
+      .else(() => null)
+
+  StaticCheck<IsSubtype<number | boolean | null, ReturnType<typeof apply>>>()
+
+  it('returns value if matches an expression', () => {
+    expect(apply({ type: 'INCREMENT' })).toEqual(2)
+    expect(apply({ type: 'DECREMENT' })).toEqual(true)
+  })
+
+  it('returns default value if no match', () => {
+    expect(apply({ type: 'Hello' })).toBeNull()
+    expect(apply({ type: 'World' })).toBeNull()
+  })
+})
+
+describe("'when.true' syntax with assertion wrapped in thunk", () => {
+  const isBuffer = (obj: { isBuffer: () => boolean }) =>
+    when
+      .true(obj.isBuffer, 1)
+      .else(2)
+
+  StaticCheck<IsSubtype<number, ReturnType<typeof isBuffer>>>()
+
+  it('unwraps the thunk', () => {
+    expect(isBuffer({isBuffer: () => true})).toBe(1)
+    expect(isBuffer({isBuffer: () => false})).toBe(2)
+  })
+})

--- a/src/when.ts
+++ b/src/when.ts
@@ -23,13 +23,19 @@ export type When<T, V> = {
     returnValue: ((inputValue: U) => W) | W
   ) => When<T, V | W>
 
-  else: <W>(returnValue: Callable<T, W> | W) => V | W
+  else: <W>(returnValue: ((inputValue: T) => W) | W) => V | W
 }
 
-export type Callable<T, V> = (inputValue: T) => V
+export interface WhenSwitch {
+  <T>(expr: T): When<T, never>
+  
+  /** Tests assertion and returns _value_ if assertion is true. */
+  true: <T>(assertion: (() => boolean) | boolean, value: (() => T) | T) => True<T>
+}
 
-function isCallable<T, V>(inputValue: any): inputValue is Callable<T, V> {
-  return typeof inputValue === 'function'
+export type True<T> = {
+  true: <U>(assertion: (() => boolean) | boolean, value: (() => U) | U) => True<T | U>,
+  else: <U>(returnValue: (() => U) | U) => T | U
 }
 
 /**
@@ -45,19 +51,39 @@ const resolve = (resolvedValue: any): When<any, any> => ({
 /**
  * Tests an object against multiple expressions.
  */
-export const when = <T>(expr: T): When<T, never> => ({
+export const when = (<T>(expr: T): When<T, never> => ({
   is: (constExpr, value) =>
     expr === constExpr
-      ? resolve(isCallable(value) ? value(constExpr) : value)
+      ? resolve(typeof value === 'function' ? (value as (x: any) => any)(constExpr) : value)
       : when(expr),
 
   match: (matcher, value) =>
     matcher.test(expr)
-      ? resolve(isCallable(value) ? value(expr) : value)
+      ? resolve(typeof value === 'function' ? (value as (x: any) => any)(expr) : value)
       : when(expr),
 
   else: defaultValue =>
-    isCallable<T, any>(defaultValue) ? defaultValue(expr) : defaultValue
+    typeof defaultValue === 'function' ? (defaultValue as (x: any) => any)(expr) : defaultValue
+})) as WhenSwitch
+
+/**
+ * Exposes same API as `true`, but just propagates a resolved value,
+ * without doing any further test.
+ */
+const resolveAssertion = (resolvedValue: any): True<any> => ({
+  true: () => resolveAssertion(resolvedValue),
+  else: () => resolvedValue
 })
+
+when.true = <T>(assertion: (() => boolean) | boolean, value: (() => T) | T): True<T> =>
+  (typeof assertion === 'function' ? assertion() : assertion)
+    ? resolveAssertion(typeof value === 'function' ? (value as (() => any))() : value)
+    : ({
+      true: when.true,
+      else: defaultValue =>
+        typeof defaultValue === 'function'
+          ? (defaultValue as (() => any))()
+          : defaultValue
+    })
 
 export default when


### PR DESCRIPTION
Because Typescript didn't want to compile, I had to add type casts.
For example, in line 57 I have changed
```typescript
value(constExpr)
```
to:
```typescript
(value as (x: any) => any)(constExpr)
```